### PR TITLE
Allow .sas benchmark suites identical naming conventions as .pddl.

### DIFF
--- a/downward/suites.py
+++ b/downward/suites.py
@@ -128,7 +128,9 @@ def _generate_problems(benchmarks_dir, description):
     elif ":" in description:
         domain_name, problem_name = description.split(":", 1)
         problem_file = os.path.join(benchmarks_dir, domain_name, problem_name)
-        domain_file = find_domain_file(benchmarks_dir, domain_name, problem_name)
+        domain_file = None
+        if description.endswith(".pddl"):
+            find_domain_file(benchmarks_dir, domain_name, problem_name)
         yield Problem(
             domain_name,
             problem_name,

--- a/downward/suites.py
+++ b/downward/suites.py
@@ -130,7 +130,7 @@ def _generate_problems(benchmarks_dir, description):
         problem_file = os.path.join(benchmarks_dir, domain_name, problem_name)
         domain_file = None
         if description.endswith(".pddl"):
-            find_domain_file(benchmarks_dir, domain_name, problem_name)
+            domain_file = find_domain_file(benchmarks_dir, domain_name, problem_name)
         yield Problem(
             domain_name,
             problem_name,


### PR DESCRIPTION
Previously an error occurred when submitting a `description` of the form `domain:problem` (a single file of a problem domain) to `_generate_problems`. Now, the domain file is only searched in case the `description` refers to a PDDL file.