### PR TITLE
catch OverFlowError when casting large ints to flaots

### DIFF
--- a/downward/reports/compare.py
+++ b/downward/reports/compare.py
@@ -137,7 +137,7 @@ class DiffColumnsModule(reports.DynamicDataModule):
                 values = [table[row_name].get(col_name, None) for col_name in col_names]
                 try:
                     diff = float(values[1]) - float(values[0])
-                except (ValueError, TypeError):
+                except (ValueError, TypeError, OverflowError):
                     diff = None
                 if diff is not None:
                     non_none_values.append(diff)

--- a/lab/tools.py
+++ b/lab/tools.py
@@ -432,15 +432,19 @@ def get_colors(cells, min_wins):
             min_wins = True
 
     # If we land here, both min_value and max_value are not None.
-    diff = float(max_value - min_value)
+    try:
+        diff = float(max_value - min_value)
+    except OverflowError:
+        diff = None
 
-    for col, val in cells.items():
-        if val is not None:
-            if diff == 0:
-                fraction = 0
-            else:
-                fraction = (val - min_value) / diff
-            result[col] = get_color(fraction, min_wins)
+    if diff is not None:
+        for col, val in cells.items():
+            if val is not None:
+                if diff == 0:
+                    fraction = 0
+                else:
+                    fraction = (val - min_value) / diff
+                result[col] = get_color(fraction, min_wins)
     return result
 
 

--- a/lab/tools.py
+++ b/lab/tools.py
@@ -435,16 +435,15 @@ def get_colors(cells, min_wins):
     try:
         diff = float(max_value - min_value)
     except OverflowError:
-        diff = None
+        return result
 
-    if diff is not None:
-        for col, val in cells.items():
-            if val is not None:
-                if diff == 0:
-                    fraction = 0
-                else:
-                    fraction = (val - min_value) / diff
-                result[col] = get_color(fraction, min_wins)
+    for col, val in cells.items():
+        if val is not None:
+            if diff == 0:
+                fraction = 0
+            else:
+                fraction = (val - min_value) / diff
+            result[col] = get_color(fraction, min_wins)
     return result
 
 


### PR DESCRIPTION
When having very large integer values, the comparison report crashes when attempting to cast them to floating point values. This PR applies a simple fix.

Note that I don't really know why or if the diff value has to be a float, but I assume there is reason. 