### PR TITLE
Add cpus_per_task parameter and adapt docstrings.

### DIFF
--- a/lab/data/slurm-job-header.template
+++ b/lab/data/slurm-job-header.template
@@ -14,7 +14,7 @@
 #SBATCH --time=%(time_limit_per_task)s
 ### Set memory limit.
 #SBATCH --mem-per-cpu=%(memory_per_cpu)s
-### Set amount of cores per task.
+### Set number of cores per task.
 #SBATCH --cpus-per-task=%(cpus_per_task)s
 ### Number of tasks in array job.
 #SBATCH --array=1-%(num_tasks)d

--- a/lab/data/slurm-job-header.template
+++ b/lab/data/slurm-job-header.template
@@ -14,6 +14,8 @@
 #SBATCH --time=%(time_limit_per_task)s
 ### Set memory limit.
 #SBATCH --mem-per-cpu=%(memory_per_cpu)s
+### Set amount of cores per task.
+#SBATCH --cpus-per-task=%(cpus_per_task)s
 ### Number of tasks in array job.
 #SBATCH --array=1-%(num_tasks)d
 ### Adjustment to priority ([-2147483645, 2147483645]).

--- a/lab/environments.py
+++ b/lab/environments.py
@@ -350,7 +350,7 @@ class SlurmEnvironment(GridEnvironment):
         >>> env = BaselSlurmEnvironment(
         ...     partition="infai_2",
         ...     memory_per_cpu="6G",
-        ...     cpus_per_task=4,
+        ...     cpus_per_task=2,
         ... )
 
         Use *export* to specify a list of environment variables that

--- a/lab/environments.py
+++ b/lab/environments.py
@@ -135,9 +135,10 @@ class GridEnvironment(Environment):
 
         Use *extra_options* to pass additional options. The
         *extra_options* string may contain newlines. Slurm example that
-        reserves two cores per run::
+        uses a given set of nodes (additional nodes will be used if the
+        given ones don't satisfy the resource constraints)::
 
-            extra_options='#SBATCH --cpus-per-task=2'
+            extra_options='#SBATCH --nodelist=ase[1-5,7,10]'
 
         See :py:class:`~lab.environments.Environment` for inherited
         parameters.

--- a/lab/environments.py
+++ b/lab/environments.py
@@ -329,8 +329,8 @@ class SlurmEnvironment(GridEnvironment):
         slack). We use a soft instead of a hard limit so that child
         processes can raise the limit.
 
-        *cpus_per_task* sets the amount of cores to be allocated per Slurm
-        task. If it is not used, it defaults to 1.
+        *cpus_per_task* sets the number of cores to be allocated per Slurm
+        task. If it is not given, it defaults to 1.
 
         Examples that reserve the maximum amount of memory available per core:
 


### PR DESCRIPTION
Summary of the changes:
- A new parameter ```cpus_per_task``` was added to the SlurmEnvironment class.
- The docstring examples were adapted, since now the Slurm parameter ```--cpus-per-task``` is not set via the ```extra_options``` parameter of SlurmEnvironment anymore.
- Internally, though, ```cpus_per_task``` is added to ```extra_options```.
- ```cpus_per_task``` is used as a multiplier for the soft memory limit of a Slurm job.