### PR TITLE
Reduce error output from fetch and report steps

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -7,6 +7,7 @@ next (unreleased)
 Lab
 ^^^
 * Allow passing properties files to fetchers directly (Jendrik Seipp).
+* Let fetch and report steps log onyl the total number of unexplained errors instead of printing all of them to stderr (Jendrik Seipp).
 
 Downward Lab
 ^^^^^^^^^^^^

--- a/downward/reports/__init__.py
+++ b/downward/reports/__init__.py
@@ -144,7 +144,7 @@ class PlanningReport(Report):
             int(bool(tools.get_unexplained_errors_message(run)))
             for run in self.runs.values()
         )
-        func = logging.info if num_unexplained_errors == 0 else logging.error
+        func = logging.info if num_unexplained_errors == 0 else logging.warning
         func(
             f"Report contains {num_unexplained_errors} runs with unexplained"
             f" errors."
@@ -227,7 +227,6 @@ class PlanningReport(Report):
         for run in self.runs.values():
             error_message = tools.get_unexplained_errors_message(run)
             if error_message:
-                logging.error(error_message)
                 run_dir = run["run_dir"]
                 for attr in self.ERROR_ATTRIBUTES:
                     value = run.get(attr, "?")
@@ -256,7 +255,7 @@ class PlanningReport(Report):
                     f"There was output to {slurm_err_file}. Below is the output without"
                     f'"memory cg" errors:\n```\n{slurm_err_content}\n```'
                 )
-            logging.error(f"There was output to {slurm_err_file}.")
+            logging.warning(f"There was output to {slurm_err_file}.")
 
         if table:
             errors.append(str(table))

--- a/lab/fetcher.py
+++ b/lab/fetcher.py
@@ -136,7 +136,7 @@ class Fetcher:
                 slurm_err_content = ""
 
             if slurm_err_content:
-                logging.error("There was output to *-grid-steps/slurm.err")
+                logging.warning("There was output to *-grid-steps/slurm.err")
 
             new_props = tools.Properties()
             run_dirs = sorted(src_dir.glob("runs-*-*/*"))
@@ -159,12 +159,12 @@ class Fetcher:
         for props in combined_props.values():
             error_message = tools.get_unexplained_errors_message(props)
             if error_message:
-                logging.error(error_message)
                 unexplained_errors += 1
 
         tools.makedirs(eval_dir)
         combined_props.write()
-        logging.info(
-            f"Wrote properties file (contains {unexplained_errors} "
-            f"runs with unexplained errors)."
+        func = logging.info if unexplained_errors == 0 else logging.warning
+        func(
+            f"Wrote properties file. It contains {unexplained_errors} "
+            f"runs with unexplained errors."
         )


### PR DESCRIPTION
Let Fetcher and reports log number of unexplained errors instead of printing all of them to stderr.