### PR TITLE
Avoid installing uv by blindly executing a script

### DIFF
--- a/examples/downward/README.md
+++ b/examples/downward/README.md
@@ -2,7 +2,21 @@
 
 Install `uv`:
 
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+First, check if `uv` is currently installed:
+
+    which uv
+
+If the previous command did not return a path, then install `uv` by using the package from your Linux distribution.
+If `uv` is not packaged for your distribution, you do not have superuser rights or you are in a non-Linux OS, you
+can install it for your user with pip:
+
+    pip install --user uv
+
+You can also check that the official installation script is safe and install it mamnually. Take into account that
+blindly executing a script is a potential security issue easy to avoid, and that official URLs can also be hacked.
+
+    wget https://astral.sh/uv/install.sh
+    sh install.sh
 
 ## Create a new project (pyproject.toml, .python-version, uv.lock)
 


### PR DESCRIPTION
Blindly executing a script is a potential security issue easy to avoid. Describing its potential harness may not only avoid installing malware in case the official URL is compromised but also teach a basic security measure to the readers.

I am not sure where this `README.md` is shown, but I think that something like this should be used for all installation instructions.

Note: Other methods to install `uv` exist, like Nix, devenv.sh or compiling with `cargo`, but listing all installation methods is probably overwhelming and overkill.