### PR TITLE
Only unique data points in scatter plots

### DIFF
--- a/downward/reports/scatter.py
+++ b/downward/reports/scatter.py
@@ -364,8 +364,6 @@ class ScatterPlotReport(PlanningReport):
             self.categories = self._handle_missing_values(self.categories)
         if not self.categories:
             logging.critical("Plot contains no points.")
-        for category, coords in self.categories.items():
-            self.categories[category] = list(set(coords))
 
         self.xlabel = self._get_axis_label(self.xlabel, self.algorithms[0], x_wins)
         self.ylabel = self._get_axis_label(self.ylabel, self.algorithms[1], y_wins)

--- a/downward/reports/scatter.py
+++ b/downward/reports/scatter.py
@@ -364,6 +364,8 @@ class ScatterPlotReport(PlanningReport):
             self.categories = self._handle_missing_values(self.categories)
         if not self.categories:
             logging.critical("Plot contains no points.")
+        for category, coords in self.categories.items():
+            self.categories[category] = list(set(coords))
 
         self.xlabel = self._get_axis_label(self.xlabel, self.algorithms[0], x_wins)
         self.ylabel = self._get_axis_label(self.ylabel, self.algorithms[1], y_wins)

--- a/downward/reports/scatter_pgfplots.py
+++ b/downward/reports/scatter_pgfplots.py
@@ -14,11 +14,13 @@ class ScatterPgfplots:
         if report.y_upper is not None:
             options["ymax"] = report.y_upper
         lines.append(f"\\begin{{axis}}[{cls._format_options(options)}]")
+        lines.append(r"% For each category, each mark is listed only once.")
         for category, coords in sorted(report.categories.items()):
+            # For each category, print each coordinate only once.
             lines.append(
                 "\\addplot+[{}] coordinates {{\n{}\n}};".format(
                     cls._format_options({"only marks": True}),
-                    " ".join(str(c) for c in coords),
+                    " ".join(str(c) for c in set(coords)),
                 )
             )
             if category:

--- a/downward/reports/scatter_pgfplots.py
+++ b/downward/reports/scatter_pgfplots.py
@@ -20,7 +20,7 @@ class ScatterPgfplots:
             lines.append(
                 "\\addplot+[{}] coordinates {{\n{}\n}};".format(
                     cls._format_options({"only marks": True}),
-                    " ".join(str(c) for c in set(coords)),
+                    " ".join(str(c) for c in sorted(set(coords))),
                 )
             )
             if category:


### PR DESCRIPTION
Filter scatter plot output for unique points to reduce the data in scatter plots.

This an opinionated change that can drastically reduce the size and compile time of tex files produced by lab, but
some might prefer to set some opacity on the markers instead.